### PR TITLE
Update streamlisten.rs

### DIFF
--- a/examples/streamlisten.rs
+++ b/examples/streamlisten.rs
@@ -2,7 +2,7 @@ extern crate pcap;
 extern crate futures;
 extern crate tokio_core;
 
-use pcap::{Capture, Packet, Error};
+use pcap::{Capture, Packet, Error, Device};
 use pcap::tokio::PacketCodec;
 use tokio_core::reactor::Core;
 use futures::stream::Stream;
@@ -21,7 +21,7 @@ impl PacketCodec for SimpleDumpCodec{
 fn ma1n() -> Result<(),Error> {
     let mut core = Core::new().unwrap();
     let handle = core.handle();
-    let cap = Capture::from_device("en0")?.open()?.setnonblock()?;
+    let cap = Capture::from_device(Device::lookup()?)?.open()?.setnonblock()?;
     let s = cap.stream(&handle, SimpleDumpCodec{})?;
     let done = s.for_each(move |s| {
         println!("{:?}", s);


### PR DESCRIPTION
use the default device instead of en0 (for me the default device is enp9s0 for others maybe eth0 or wlan0 or wlp8s0, so let pcap choose)

an alternative might be to let the user sepcify a device on the command line, but this is just an example